### PR TITLE
增加微信提醒的方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ python3 main.py --bupt-sso-pass=114514 --stop-when-sick
 
 若您部署脚本的目标平台既不提供环境变量功能，也不允许设置命令行参数，那么您可以通过修改代码的方式提供配置。找到 CONFIG_SCHEMA 变量，给对应配置的 default 属性填入您的值即可。
 
+## 配置server酱推送结果到微信
+
+server酱可以非常简单的配置结果推送，字需要微信绑定即可，使用方法请见[server酱官网](http://sc.ftqq.com/)
+
+在server酱官网登录并绑定微信后能获得一个SCKEY，将SCKEY作为参数传入即可：
+
+```bash
+export BUPT_SSO_USER=2020114514
+python3 main.py --bupt-sso-pass=114514 --server-chan-sckey=xxxxxxxx
+```
+
 
 
 ## 配置代理以连接 Telegram 服务器

--- a/bupt_ncov_report/program/program.py
+++ b/bupt_ncov_report/program/program.py
@@ -241,7 +241,7 @@ class Program:
                                      f'您输入的SCKEY为\n{self._conf["SERVER_CHAN_SCKEY"]}')
 
             except:
-                # 将 Telegram 机器人的错误也打印下来
+                # 将 SERVER酱 机器人的错误也打印下来
                 logger.error('调用 SERVER酱 API 时发生错误。', exc_info=True)
                 success = False
 

--- a/main.py
+++ b/main.py
@@ -51,6 +51,13 @@ CONFIG_SCHEMA: Dict[str, ConfigSchemaItem] = {
         default=False,
         type=bool,
     ),
+    'SERVER_CHAN_SCKEY': ConfigSchemaItem(
+        description='（可选）如果您需要把执行结果通过SERVER酱(http://sc.ftqq.com/3.version)推送的微信，'
+                    '请设为SERVER酱为您提供的专属用户SCKEY',
+        for_short='用户SCKEY',
+        default=False,
+        type=str,
+    ),
 }
 PROGRAM_DESC = '自动填写北邮「疫情防控通」的每日上报信息。'
 


### PR DESCRIPTION
增加使用[erver酱]的服务，将运行成功的信息推送到手机微信
增加一个参数  SERVER_CHAN_SCKEY
推送部分的代码与Telegram基本相似
项目的README中也增加了响应的说明