### PR TITLE
添加对“晨午晚检”的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ GitHub.sublime-settings
 .mypy_cache/
 .dmypy.json
 dmypy.json
+__pycache__/
 
 # CUSTOM: zip files and batch scripts
 *.zip

--- a/bupt_ncov_report/constant/constant.py
+++ b/bupt_ncov_report/constant/constant.py
@@ -2,6 +2,8 @@
 LOGIN_API = 'https://app.bupt.edu.cn/uc/wap/login/check'
 REPORT_PAGE = 'https://app.bupt.edu.cn/ncov/wap/default/index'
 REPORT_API = 'https://app.bupt.edu.cn/ncov/wap/default/save'
+DAILYUP_PAGE = 'https://app.bupt.edu.cn/xisuncov/wap/open-report/index'
+DAILYUP_API = 'https://app.bupt.edu.cn/xisuncov/wap/open-report/save'
 
 # 不能再短了，再短肯定是出 bug 了
 REASONABLE_LENGTH = 24

--- a/bupt_ncov_report/program/program.py
+++ b/bupt_ncov_report/program/program.py
@@ -172,6 +172,65 @@ class Program:
 
         return report_api_res.text
 
+    def do_dailyup_report(self) -> str:
+        """
+        进行信息上报的工作函数，包含本脚本主要逻辑。
+        :return: 上报 API 的返回内容。
+        """
+        # 登录北邮 nCoV 上报网站
+        logger.info('登录北邮 nCoV 上报网站')
+        login_res = self._sess.post(LOGIN_API, data={
+            'username': cast(str, self._conf['BUPT_SSO_USER']),
+            'password': cast(str, self._conf['BUPT_SSO_PASS']),
+        }, headers={
+            **self.COMMON_HEADERS,
+            **self.COMMON_POST_HEADERS,
+            'Referer': HEADERS.REFERER_LOGIN_API,
+        })
+        if login_res.status_code != 200:
+            logger.debug(f'登录页：\n'
+                         f'status code: {login_res.status_code}\n'
+                         f'url: {login_res.url}')
+            raise RuntimeError('登录 API 返回的 HTTP 状态码不是 200。')
+
+        # 获取上报页面的数据
+        report_page_res = self._sess.get(DAILYUP_PAGE, headers={
+            **self.COMMON_HEADERS,
+            'Accept': HEADERS.ACCEPT_HTML,
+        })
+        logger.debug(f'报告页：\n'
+                     f'status code: {report_page_res.status_code}\n'
+                     f'url: {report_page_res.url}')
+        if report_page_res.status_code != 200:
+            raise RuntimeError('上报页面的 HTTP 状态码不是 200。')
+        if report_page_res.url != DAILYUP_PAGE:
+            raise RuntimeError('访问上报页面时被重定向。一般来说原因是登录操作失败了；您的北邮账号和密码可能有误。')
+        page_html = report_page_res.text
+
+        # 从上报页面中提取 POST 的参数
+        post_data = self._prog_util.extract_post_data_dailyup(page_html)
+        logger.debug(f'最终提交参数：{json.dumps(post_data)}')
+
+        # 检查上报参数有没有异常
+        if self._conf['STOP_WHEN_SICK']:
+            verified_data = self._prog_util.verify_data(post_data)
+            self._prog_util.check_data_sick(verified_data)
+
+        # 最终 POST
+        report_api_res = self._sess.post(
+            DAILYUP_API,
+            data=post_data,
+            headers={
+                **self.COMMON_HEADERS,
+                **self.COMMON_POST_HEADERS,
+                'Referer': HEADERS.REFERER_POST_API,
+            },
+        )
+        if report_api_res.status_code != 200:
+            raise RuntimeError(f'上报 API 返回的 HTTP 状态码（{report_api_res.status_code}）不是 200。')
+
+        return report_api_res.text
+
     def main(self) -> str:
         """
         真正的主函数。
@@ -185,6 +244,41 @@ class Program:
         success = True
         try:
             res = self.do_ncov_report()
+        except:
+            success = False
+            res = traceback.format_exc()
+
+        # 生成消息并打印到控制台
+        if success:
+            logger.info(f'成功：服务器的返回是：\n\n{res}')
+        else:
+            logger.info(f'失败：发生如下异常：\n\n{res}')
+
+        # 将执行结果通过 INotifier 通知用户
+        for notifier in self._notifiers:
+            logger.info(f'通过「{notifier.PLATFORM_NAME}」给用户发送通知')
+            try:
+                notifier.notify(success=success, msg=res)
+            except:
+                logger.exception(f'使用「{notifier.PLATFORM_NAME}」通知失败，发生异常：')
+
+        if not success:
+            self._exit_status = 1
+        return res
+
+    def main2(self) -> str:
+        """
+        真正的主函数。
+        该函数读取程序配置，并尝试调用工作函数；
+        该函数随后获取工作函数的返回值或异常内容，通过 INotifier 发送给用户。
+
+        :return: 通过 INotifier 发送的信息
+        """
+        # 运行工作函数
+        logger.info('运行工作函数')
+        success = True
+        try:
+            res = self.do_dailyup_report()
         except:
             success = False
             res = traceback.format_exc()

--- a/bupt_ncov_report/program_utils/program_utils.py
+++ b/bupt_ncov_report/program_utils/program_utils.py
@@ -46,6 +46,28 @@ class ProgramUtils:
 
         return old_dict
 
+    def extract_post_data_dailyup(self, html: str) -> Dict[str, Any]:
+        """
+        从上报页面的 HTML 中，提取出上报 API 所需要填写的参数。
+
+        :param html: 上报页 HTML
+        :return: dict 类型，可用于最终上报时提交的参数
+        """
+        old_dict = json.loads(html)['d']['info']
+
+        # 需要从 old dict 中删除如下数据
+        PICK_PROPS = (
+            'created', 'creator', 'date', 'flag','id','uid'
+        )
+
+        for prop in PICK_PROPS:
+            val = old_dict.pop(prop, None)
+            if val is None:
+                raise RuntimeError(f'从网页上提取的 old data 中缺少属性 {prop}，可能网页已经改版。')
+
+
+        return old_dict
+
     def extract_old_new_data(self, html: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
         从页面 HTML 中提取 def 变量与 oldInfo 变量的值（分别叫做 new 与 old data），并用 Python dict 的形式返回。

--- a/main2.py
+++ b/main2.py
@@ -1,0 +1,136 @@
+__all__ = (
+    'main',
+)
+
+from typing import Dict, List, Optional, cast
+
+import requests
+
+from bupt_ncov_report import *
+from kv_config_reader import *
+
+# 该变量用于给每一个设置项生成文档。
+# 如果您无法设置环境变量、命令行参数，可以在此处指定默认值；详情参考文档。
+CONFIG_SCHEMA: Dict[str, ConfigSchemaItem] = {
+    'BUPT_SSO_USER': ConfigSchemaItem(
+        description='您登录北邮门户（https://my.bupt.edu.cn/）时使用的用户名，通常是您的学工号',
+        for_short='北邮账号',
+        default=None,
+        type=str,
+    ),
+    'BUPT_SSO_PASS': ConfigSchemaItem(
+        description='您登录北邮门户（https://my.bupt.edu.cn/）时使用的密码',
+        for_short='北邮密码',
+        default=None,
+        type=str,
+    ),
+    'TG_BOT_TOKEN': ConfigSchemaItem(
+        description='（可选）如果您需要把执行结果通过 Telegram 机器人告知，'
+                    '请设为您的 Telegram 机器人的 API Token',
+        for_short='Bot Token',
+        default=None,
+        type=str,
+    ),
+    'TG_CHAT_ID': ConfigSchemaItem(
+        description='（可选）如果您需要把执行结果通过 Telegram 机器人告知，'
+                    '请设为您自己的用户 id',
+        for_short='用户 ID',
+        default=None,
+        type=str,
+    ),
+    'BNR_LOG_PATH': ConfigSchemaItem(
+        description='（可选）日志文件存放的路径，未设置则不输出日志文件。（注意日志中可能有敏感信息）',
+        for_short='路径',
+        default=None,
+        type=str,
+    ),
+    'STOP_WHEN_SICK': ConfigSchemaItem(
+        description='（可选）当检测到您上报的数据表明您为疑似病患时（如体温>=37°C、接触过确诊人群等），'
+                    '若您开启了此选项，将停止自动上报，以防止您连续多日上报异常数据。',
+        for_short='',
+        default=False,
+        type=bool,
+    ),
+    'SERVER_CHAN_SCKEY': ConfigSchemaItem(
+        description='（可选）如果您需要把执行结果通过 Server 酱推送到微信，请设为 Server 酱为您提供的 SCKEY。',
+        for_short='SCKEY',
+        default=None,
+        type=str,
+    ),
+}
+PROGRAM_DESC = '自动填写北邮「疫情防控通」的每日上报信息。'
+
+
+def fill_config(config: Dict[str, Optional[ConfigValue]]) -> None:
+    """
+    往 _conf 中按照 env、cmdargs 的顺序填入配置值。
+    :param config: dict 对象
+    :return: None
+    """
+
+    fillers: List[IFiller] = [
+        EnvFiller(),
+        CmdArgsFiller(description=PROGRAM_DESC),
+    ]
+
+    for filler in fillers:
+        filler.fill(config, CONFIG_SCHEMA)
+
+
+def initialize_notifier(config: Dict[str, Optional[ConfigValue]]) -> List[INotifier]:
+    """
+    初始化 Notifier 对象，用于实现运行结果通知用户的功能。
+    :param config: 通过 kv_config_reader 获取到的配置
+    :return: list，元素是 INotifier 的子类
+    """
+    res: List[INotifier] = []
+
+    # 检查两个 Telegram 参数是否未同时填写
+    if bool(config['TG_BOT_TOKEN']) != bool(config['TG_CHAT_ID']):
+        raise ValueError('TG_BOT_TOKEN 与 TG_CHAT_ID 必须同时填写。')
+
+    # 若两个 Telegram 参数都填写了，则初始化 Telegram 通知器
+    if config['TG_BOT_TOKEN'] and config['TG_CHAT_ID']:
+        res.append(TelegramNotifier(
+            token=cast(str, config['TG_BOT_TOKEN']),
+            chat_id=cast(str, config['TG_CHAT_ID']),
+            session=requests.Session(),
+        ))
+
+    # 如果填写了 SCKEY，就初始化 Server 酱通知器
+    if config['SERVER_CHAN_SCKEY']:
+        res.append(ServerChanNotifier(
+            sckey=cast(str, config['SERVER_CHAN_SCKEY']),
+            sess=requests.Session(),
+        ))
+
+    return res
+
+
+def main(*wtf: object, **kwwtf: object) -> object:
+    """
+    入口函数。该函数用于在允许直接运行的同时，兼容 GCP Cloud Function/AWS Lambda 等云函数平台。
+    :return: 由检测到的平台决定
+    """
+
+    config: Dict[str, Optional[ConfigValue]] = initialize_config(CONFIG_SCHEMA)
+    fill_config(config)
+
+    # 搭积木；手动建立各个类的实例，并注入依赖
+    notifiers = initialize_notifier(config)
+    pure_util = PureUtils()
+    program = Program(
+        config=config,
+        program_utils=ProgramUtils(pure_util),
+        session=requests.Session(),
+        notifiers=notifiers,
+    )
+
+    # 运行程序
+    program.main2()
+    return program.get_exit_status()
+
+
+if __name__ == '__main__':
+    status_code = main()
+    exit(status_code)


### PR DESCRIPTION
复制粘贴大量代码
原理还是和每日填报一模一样，先抓取oldinfo再post回去
其实就是加了一个魔改版的extract_post_data_dailyup()
然后main2.py是晨午晚检
虽然不优雅但又不是不能用